### PR TITLE
[FEAT] Add SSL certificate and TLS configuration to Gateway service - PIT-334

### DIFF
--- a/charts/loventure/charts/gateway/templates/service.yaml
+++ b/charts/loventure/charts/gateway/templates/service.yaml
@@ -4,6 +4,14 @@ metadata:
   name: {{ include "gateway.fullname" . }}
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.loadBalancer.enabled }}
+  annotations:
+    cloud.google.com/load-balancer-type: "External"
+    {{- if .Values.loadBalancer.sslCertificates }}
+    cloud.google.com/load-balancer-ssl-certificates: {{ .Values.loadBalancer.sslCertificates }}
+    cloud.google.com/load-balancer-backend-protocol: "HTTP"
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.loadBalancer.ip }}

--- a/charts/loventure/templates/gateway-loadbalancer.yaml
+++ b/charts/loventure/templates/gateway-loadbalancer.yaml
@@ -1,4 +1,4 @@
-{{- if false }}
+{{- if .Values.gateway.loadBalancer.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/component: gateway
   annotations:
     cloud.google.com/load-balancer-type: "External"
+    {{- if .Values.gateway.loadBalancer.sslCertificates }}
+    cloud.google.com/load-balancer-ssl-certificates: {{ .Values.gateway.loadBalancer.sslCertificates }}
+    cloud.google.com/load-balancer-backend-protocol: "HTTP"
+    {{- end }}
 spec:
   type: LoadBalancer
   {{- if .Values.gateway.loadBalancer.ip }}

--- a/charts/loventure/values.yaml
+++ b/charts/loventure/values.yaml
@@ -18,6 +18,7 @@ gateway:
   loadBalancer:
     enabled: true
     ip: "34.22.65.113"  # GCP에서 할당된 정적 IP 주소를 여기에 입력
+    sslCertificates: "pitterpetter-ssl"  # GCP Self-Managed SSL 인증서
     ports:
       http: 80
       https: 443


### PR DESCRIPTION
## 📝 목적/배경
Gateway 서비스에 SSL 인증서를 연결하여 HTTPS 통신을 지원하도록 설정

## 🔧 주요 작업(변경) 사항
- GCP LoadBalancer에서 SSL 종료 처리하도록 설정
- pitterpetter-ssl 인증서를 Gateway 서비스에 연결
- 고정 IP 34.22.65.113 유지하면서 HTTPS 지원
- 내부 통신은 HTTP로 유지하여 성능 최적화

## 🎥 스크린샷/데모 (선택)

## 🔗 이슈 연결
- PIT-334

## ✅ 체크리스트
- [x] merge branch 가 develop 인지 확인
- [x] 모든 코드가 잘 작동하는지 확인
- [x] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타