### PR TITLE
 [FEAT] Add ingress path for Oauth verification - PIT-431

### DIFF
--- a/charts/loventure/values.yaml
+++ b/charts/loventure/values.yaml
@@ -62,6 +62,14 @@ gateway:
             pathType: "Prefix"
           - path: "/actuator"
             pathType: "Prefix"
+          - path: "/oauth2"
+            pathType: "Prefix"
+          - path: "/login/oauth2"
+            pathType: "Prefix"
+          - path: "/login/oauth2/code"
+            pathType: "Prefix"
+          - path: "/logout"
+            pathType: "Prefix"
     tls:
       enabled: true
       secretName: "pitterpetter-ssl"


### PR DESCRIPTION
## 📝 목적/배경
oauth 인증에 사용되는 경로 허용
## 🔧 주요 작업(변경) 사항
- [ ] 게이트웨이 인그레스 설정 변경
- [ ] oauth 경로 확인 후 세팅

## 🎥 스크린샷/데모 (선택)

## 🔗 이슈 연결
- PIT-431

## ✅ 체크리스트
- [ ] merge branch 가 develop 인지 확인
- [ ] 모든 코드가 잘 작동하는지 확인
- [ ] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타